### PR TITLE
Made ruby portable

### DIFF
--- a/taoup
+++ b/taoup
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 # encoding: utf-8
 
 require 'ansi/code'


### PR DESCRIPTION
Previous she-bang statement `#!/usr/bin/ruby` assumed that ruby is installed exactly in that directory.
This modification will let `env` scan for the user's ruby directory and execute from there.