### PR TITLE
README: update dead Arch/AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It's mostly a personal collection, but contributions are welcome.
 Installation
 ------------
 
- * [Arch Linux](https://aur.archlinux.org/packages/taoup/): `pacman -S taoup` (thanks to @JoshH100)
+ * [Arch Linux](https://aur.archlinux.org/packages/taoup-git/): `yay -S taoup-git` (replace `yay` with your favorite AUR helper)
  * Other unix-like: Make sure you have `ruby` and `gem` installed, run `gem install ansi` then `./taoup`.
 
 Screenshots


### PR DESCRIPTION
Looks like https://aur.archlinux.org/packages/taoup/ is dead (, Jim).

But rejoice! https://aur.archlinux.org/packages/taoup-git/ is alive!
I don't know the author, but:
1. I reviewed its `PKGBUILD` and it doesn't seem nefarious:
   https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=taoup-git
2. I tested it, it works.

Also, replacing the suggestion to use `pacman` (which won't work for AUR packages)
with a suggestion to use `yay` (the most popular AUR helper as of today) or whatever kids use.