### PR TITLE
Improve shuf usage

### DIFF
--- a/taoup-fortune
+++ b/taoup-fortune
@@ -44,7 +44,7 @@ if [ `which cowsay 2>/dev/null` ]; then
 	echo '' | cowsay -f eyes |tail -n 10 |sed 's/^/[0;32;40m/'
 else
 	# impoverished user execution path
-	if [ `shuf -e 2>/dev/null` ]; then
+	if [ `which shuf 2>/dev/null` ]; then
 	  cat ${cachefile} |grep -v '^---' | shuf | head -n 1
 	elif [ `echo test |sort -R 2>/dev/null` ]; then
 	  cat ${cachefile} |grep -v '^---' | sort -R | head -n 1

--- a/taoup-fortune
+++ b/taoup-fortune
@@ -35,7 +35,7 @@ fi
 if [ `which cowsay 2>/dev/null` ]; then
 	# educated user execution path
 	if [ `which shuf 2>/dev/null` ]; then
-	  cat ${cachefile} |grep -v '^---' | shuf | head -n 1 | cowsay -f eyes -n |head -n 2 |tail -n 1
+	  cat ${cachefile} |grep -v '^---' | shuf -n 1 | cowsay -f eyes -n |head -n 2 |tail -n 1
 	elif [ `echo test|sort -R 2>/dev/null` ]; then
 	  cat ${cachefile} |grep -v '^---' | sort -R | head -n 1 | cowsay -f eyes -n |head -n 2 |tail -n 1
         else
@@ -45,7 +45,7 @@ if [ `which cowsay 2>/dev/null` ]; then
 else
 	# impoverished user execution path
 	if [ `which shuf 2>/dev/null` ]; then
-	  cat ${cachefile} |grep -v '^---' | shuf | head -n 1
+	  cat ${cachefile} |grep -v '^---' | shuf -n 1
 	elif [ `echo test |sort -R 2>/dev/null` ]; then
 	  cat ${cachefile} |grep -v '^---' | sort -R | head -n 1
 	else


### PR DESCRIPTION
This PR fixes an erroneous availability test of `shuf` based on my previous issue report of #26, as well as remove `head` usages where it can be replaced by `shuf`. 